### PR TITLE
Add support for --network flag

### DIFF
--- a/__tests__/__snapshots__/index_test.js.snap
+++ b/__tests__/__snapshots__/index_test.js.snap
@@ -80,3 +80,19 @@ services:
             - '80:80'
         image: 'foobar/baz:latest'"
 `;
+
+exports[`snapshots match snapshots 8`] = `
+"version: '3.3'
+services:
+    pms-docker:
+        container_name: plex
+        network_mode: host
+        environment:
+            - TZ=<timezone>
+            - PLEX_CLAIM=<claimToken>
+        volumes:
+            - '<path/to/plex/database>:/config'
+            - '<path/to/transcode/temp>:/transcode'
+            - '<path/to/media>:/data'
+        image: plexinc/pms-docker"
+`;

--- a/__tests__/index_test.js
+++ b/__tests__/index_test.js
@@ -27,6 +27,9 @@ describe('snapshots', () => {
 
         // test flag
         'docker run --privileged -p 80:80 foobar/baz:latest',
+
+        // https://github.com/magicmark/composerize/issues/25
+        'docker run -d --name plex --network=host -e TZ="<timezone>" -e PLEX_CLAIM="<claimToken>" -v <path/to/plex/database>:/config -v <path/to/transcode/temp>:/transcode -v <path/to/media>:/data plexinc/pms-docker',
     ];
 
     it('match snapshots', () => {

--- a/src/mappings.js
+++ b/src/mappings.js
@@ -72,6 +72,7 @@ export const MAPPINGS: { [string]: Mapping } = {
     entrypoint: getMapping('Array', 'entrypoint'),
     env: getMapping('Array', 'environment'),
     name: getMapping('Value', 'container_name'),
+    network: getMapping('Value', 'network_mode'),
     privileged: getMapping('Switch', 'privileged'),
     publish: getMapping('Array', 'ports'),
     restart: getMapping('Value', 'restart'),


### PR DESCRIPTION
Adds support for the `--network` flag to fix https://github.com/magicmark/composerize/issues/25

(https://docs.docker.com/compose/compose-file/#network_mode)

Added a regression test here: https://github.com/magicmark/composerize/blob/fbb775570c72906084e4bdb26acf80388bff49d6/__tests__/index_test.js#L32

Snapshot shows the fix:

```
  ● snapshots › match snapshots

    expect(value).toMatchSnapshot()

    Received value does not match stored snapshot 8.

    - Snapshot
    + Received

    @@ -1,9 +1,10 @@
      "version: '3.3'
      services:
          pms-docker:
              container_name: plex
    +         network_mode: host
              environment:
                  - TZ=<timezone>
                  - PLEX_CLAIM=<claimToken>
              volumes:
                  - '<path/to/plex/database>:/config'
```