### PR TITLE
feat: add 'read-only'

### DIFF
--- a/packages/composerize/__tests__/mappings.test.js
+++ b/packages/composerize/__tests__/mappings.test.js
@@ -2,6 +2,20 @@
 
 import Composerize from '../src';
 
+test('--read-only', () => {
+    const command = 'docker run --read-only -p 80:80 foobar/baz:latest';
+
+    expect(Composerize(command)).toMatchInlineSnapshot(`
+            "version: '3.3'
+            services:
+                baz:
+                    read_only: true
+                    ports:
+                        - '80:80'
+                    image: 'foobar/baz:latest'"
+      `);
+});
+
 test('--privileged', () => {
     const command = 'docker run --privileged -p 80:80 foobar/baz:latest';
 

--- a/packages/composerize/src/logic.js
+++ b/packages/composerize/src/logic.js
@@ -38,7 +38,7 @@ export const getComposeEntry = (mapping: Mapping, value: RawValue): ComposeEntry
     if (mapping.type === 'Switch') {
         return ({
             path: mapping.path,
-            value: value === 'true' || value === true,
+            value: value === true,
         }: SwitchComposeEntry);
     }
 

--- a/packages/composerize/src/logic.js
+++ b/packages/composerize/src/logic.js
@@ -38,7 +38,7 @@ export const getComposeEntry = (mapping: Mapping, value: RawValue): ComposeEntry
     if (mapping.type === 'Switch') {
         return ({
             path: mapping.path,
-            value: value === true,
+            value: value === 'true' || value === true,
         }: SwitchComposeEntry);
     }
 

--- a/packages/composerize/src/mappings.js
+++ b/packages/composerize/src/mappings.js
@@ -72,6 +72,8 @@ export const MAPPINGS: { [string]: Mapping } = {
     expose: getMapping('Array', 'expose'),
     label: getMapping('Array', 'labels'),
     link: getMapping('Array', 'links'),
+    'log-driver': getMapping('Array', 'logging/driver'),
+    'log-opt': getMapping('KeyValue', 'logging/options'),
     entrypoint: getMapping('Array', 'entrypoint'),
     env: getMapping('Array', 'environment'),
     name: getMapping('Value', 'container_name'),
@@ -80,12 +82,11 @@ export const MAPPINGS: { [string]: Mapping } = {
     pid: getMapping('Value', 'pid'),
     privileged: getMapping('Switch', 'privileged'),
     publish: getMapping('Array', 'ports'),
+    'read-only': getMapping('Switch', 'read_only'),
     restart: getMapping('Value', 'restart'),
     tmpfs: getMapping('Value', 'tmpfs'),
     ulimit: getMapping('Ulimits', 'ulimits'),
     volume: getMapping('Array', 'volumes'),
-    'log-driver': getMapping('Array', 'logging/driver'),
-    'log-opt': getMapping('KeyValue', 'logging/options'),
 };
 
 // Add flag mappings


### PR DESCRIPTION
<!-- Short description of the thing you're adding/fixing. Link to any issues. -->

## read-only

**Input:** `docker run --read-only -p 80:80 foobar/baz:latest`
**Output:**
```yaml
version: '3.3'
services:
    baz:
        read_only: true
        ports:
            - '80:80'
        image: 'foobar/baz:latest'
```

## Relevant Docker Documentation

<!-- Please link to the source of truth for how the option should behave, according to the official Docker documentation -->

**Docker CLI:** https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only
**Docker Compose:** https://docs.docker.com/compose/compose-file/compose-file-v3/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir

## Checklist

- [x] Added a test to cover this behaviour
- [x] Verified this using the deploy preview
- [x] Behaves according the documentation pasted above