### PR TITLE
Add support for --user, -l, -h, -u flags

### DIFF
--- a/packages/composerize/__tests__/mappings.test.js
+++ b/packages/composerize/__tests__/mappings.test.js
@@ -30,8 +30,52 @@ test('--privileged', () => {
       `);
 });
 
+test('--user', () => {
+    const command = 'docker run --user 99:100 -p 80:80 foobar/baz:latest';
+
+    expect(Composerize(command)).toMatchInlineSnapshot(`
+            "version: '3.3'
+            services:
+                baz:
+                    user: '99:100'
+                    ports:
+                        - '80:80'
+                    image: 'foobar/baz:latest'"
+      `);
+});
+
+test('--label', () => {
+    const command = 'docker run --label test1=value -l test2=value -p 80:80 foobar/baz:latest';
+
+    expect(Composerize(command)).toMatchInlineSnapshot(`
+            "version: '3.3'
+            services:
+                baz:
+                    labels:
+                        - test1=value
+                        - test2=value
+                    ports:
+                        - '80:80'
+                    image: 'foobar/baz:latest'"
+      `);
+});
+
 test('--hostname', () => {
     const command = 'docker run --hostname myHostName -p 80:80 foobar/baz:latest';
+
+    expect(Composerize(command)).toMatchInlineSnapshot(`
+            "version: '3.3'
+            services:
+                baz:
+                    hostname: myHostName
+                    ports:
+                        - '80:80'
+                    image: 'foobar/baz:latest'"
+      `);
+});
+
+test('-h', () => {
+    const command = 'docker run -h myHostName -p 80:80 foobar/baz:latest';
 
     expect(Composerize(command)).toMatchInlineSnapshot(`
             "version: '3.3'

--- a/packages/composerize/src/mappings.js
+++ b/packages/composerize/src/mappings.js
@@ -87,6 +87,7 @@ export const MAPPINGS: { [string]: Mapping } = {
     restart: getMapping('Value', 'restart'),
     tmpfs: getMapping('Value', 'tmpfs'),
     ulimit: getMapping('Ulimits', 'ulimits'),
+    user: getMapping('Value', 'user'),
     volume: getMapping('Array', 'volumes'),
 };
 
@@ -94,3 +95,6 @@ export const MAPPINGS: { [string]: Mapping } = {
 MAPPINGS.v = MAPPINGS.volume;
 MAPPINGS.p = MAPPINGS.publish;
 MAPPINGS.e = MAPPINGS.env;
+MAPPINGS.l = MAPPINGS.label;
+MAPPINGS.h = MAPPINGS.hostname;
+MAPPINGS.u = MAPPINGS.user;


### PR DESCRIPTION
<!-- Short description of the thing you're adding/fixing. Link to any issues. -->

## Example

**Input:** `docker run  -h myhostname --user 99:100 -l test2=value -p 80:80 foobar/baz:latest`
**Output:**
```yaml
version: '3.3'
services:
    baz:
        hostname: myhostname
        user: '99:100'
        labels:
            - test2=value
        ports:
            - '80:80'
        image: 'foobar/baz:latest'
```

## Relevant Docker Documentation

<!-- Please link to the source of truth for how the option should behave, according to the official Docker documentation -->

**Docker CLI:** <!-- Link to the subheading of the option on https://docs.docker.com/engine/reference/commandline/run -->
See the table here for -h, -l and -u flags 
https://docs.docker.com/engine/reference/commandline/run/#options

**Docker Compose:** <!-- Link to the subheading of the option on https://docs.docker.com/compose/compose-file -->
https://docs.docker.com/compose/compose-file/#user

## Checklist

- [x] Added a test to cover this behaviour
- [x] Verified this using the deploy preview
- [x] Behaves according the documentation pasted above