### PR TITLE
Root named volumes

### DIFF
--- a/packages/composerize/__tests__/mappings.test.js
+++ b/packages/composerize/__tests__/mappings.test.js
@@ -168,3 +168,116 @@ test('--ulimit (https://github.com/magicmark/composerize/pull/262)', () => {
                 image: 'nginx:latest'"
     `);
 });
+
+test('-it image name (https://github.com/magicmark/composerize/issues/544)', () => {
+    expect(Composerize('docker run -p 8000:8000 -it ctfd/ctfd')).toMatchInlineSnapshot(`
+        "version: '3.3'
+        services:
+            ctfd:
+                ports:
+                    - '8000:8000'
+                image: ctfd/ctfd"
+    `);
+    });
+
+test('command name (https://github.com/magicmark/composerize/issues/549)', () => {
+    expect(
+        Composerize(
+            'docker run -d --name=tailscaled -v /var/lib:/var/lib -v /dev/net/tun:/dev/net/tun --network=host --privileged tailscale/tailscale tailscaled',
+        ),
+    ).toMatchInlineSnapshot(`
+        "version: '3.3'
+        services:
+            tailscale:
+                container_name: tailscaled
+                volumes:
+                    - '/var/lib:/var/lib'
+                    - '/dev/net/tun:/dev/net/tun'
+                network_mode: host
+                privileged: true
+                image: tailscale/tailscale
+                command: tailscaled"
+    `);
+    });
+
+test('command name (https://github.com/magicmark/composerize/issues/538)', () => {
+    expect(
+        Composerize(
+            'docker run -p 8080:8080 -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin quay.io/keycloak/keycloak:18.0.2 start-dev',
+        ),
+    ).toMatchInlineSnapshot(`
+        "version: '3.3'
+        services:
+            keycloak:
+                ports:
+                    - '8080:8080'
+                environment:
+                    - KEYCLOAK_ADMIN=admin
+                    - KEYCLOAK_ADMIN_PASSWORD=admin
+                image: 'quay.io/keycloak/keycloak:18.0.2'
+                command: start-dev"
+    `);
+});
+
+test('command args (https://github.com/magicmark/composerize/issues/484)', () => {
+    expect(
+        Composerize(
+            'docker run --rm -it -p 50000:50000 -p 8080:8080 --name opcplc mcr.microsoft.com/iotedge/opc-plc:latest --pn=50000 --autoaccept --nospikes --nodips --nopostrend --nonegtrend --nodatavalues --sph --sn=25 --sr=10 --st=uint --fn=5 --fr=1 --ft=uint',
+        ),
+    ).toMatchInlineSnapshot(`
+        "version: '3.3'
+        services:
+            iotedge:
+                ports:
+                    - '50000:50000'
+                    - '8080:8080'
+                container_name: opcplc
+                image: 'mcr.microsoft.com/iotedge/opc-plc:latest'
+                args:
+                    - '--pn=50000'
+                    - '--autoaccept'
+                    - '--nospikes'
+                    - '--nodips'
+                    - '--nopostrend'
+                    - '--nonegtrend'
+                    - '--nodatavalues'
+                    - '--sph'
+                    - '--sn=25'
+                    - '--sr=10'
+                    - '--st=uint'
+                    - '--fn=5'
+                    - '--fr=1'
+                    - '--ft=uint'"
+    `);
+});
+
+test('basic image (https://github.com/magicmark/composerize/issues/542)', () => {
+    expect(Composerize('docker run -d ubuntu')).toMatchInlineSnapshot(`
+        "version: '3.3'
+        services:
+            ubuntu:
+                image: ubuntu"
+    `);
+});
+
+test('tmpfs (https://github.com/magicmark/composerize/issues/536)', () => {
+    expect(
+        Composerize(
+            'docker run -dit -p 8080:5000 --tmpfs /opt/omd/sites/cmk/tmp:uid=1000,gid=1000 -v/omd/sites --name monitoring -v/etc/localtime:/etc/localtime:ro --restart always checkmk/check-mk-raw:2.0.0-latest',
+        ),
+    ).toMatchInlineSnapshot(`
+        "version: '3.3'
+        services:
+            check-mk-raw:
+                ports:
+                    - '8080:5000'
+                tmpfs: '/opt/omd/sites/cmk/tmp:uid=1000,gid=1000'
+                volumes:
+                    - /omd/sites
+                    - '/etc/localtime:/etc/localtime:ro'
+                container_name: monitoring
+                restart: always
+                image: 'checkmk/check-mk-raw:2.0.0-latest'"
+    `);
+});
+

--- a/packages/composerize/__tests__/mappings.test.js
+++ b/packages/composerize/__tests__/mappings.test.js
@@ -233,21 +233,7 @@ test('command args (https://github.com/magicmark/composerize/issues/484)', () =>
                     - '8080:8080'
                 container_name: opcplc
                 image: 'mcr.microsoft.com/iotedge/opc-plc:latest'
-                args:
-                    - '--pn=50000'
-                    - '--autoaccept'
-                    - '--nospikes'
-                    - '--nodips'
-                    - '--nopostrend'
-                    - '--nonegtrend'
-                    - '--nodatavalues'
-                    - '--sph'
-                    - '--sn=25'
-                    - '--sr=10'
-                    - '--st=uint'
-                    - '--fn=5'
-                    - '--fr=1'
-                    - '--ft=uint'"
+                command: '--pn=50000 --autoaccept --nospikes --nodips --nopostrend --nonegtrend --nodatavalues --sph --sn=25 --sr=10 --st=uint --fn=5 --fr=1 --ft=uint'"
     `);
 });
 

--- a/packages/composerize/__tests__/mappings.test.js
+++ b/packages/composerize/__tests__/mappings.test.js
@@ -333,3 +333,17 @@ test('multiline (https://github.com/magicmark/composerize/issues/120)', () => {
     `);
 });
 
+test('mount type (https://github.com/magicmark/composerize/issues/412)', () => {
+    expect(Composerize('docker run --mount type=bind,source=./logs,target=/usr/src/app/logs nginx'))
+        .toMatchInlineSnapshot(`
+        "version: '3.3'
+        services:
+            nginx:
+                volumes:
+                    -
+                        type: bind
+                        source: ./logs
+                        target: /usr/src/app/logs
+                image: nginx"
+    `);
+});

--- a/packages/composerize/__tests__/mappings.test.js
+++ b/packages/composerize/__tests__/mappings.test.js
@@ -281,3 +281,46 @@ test('tmpfs (https://github.com/magicmark/composerize/issues/536)', () => {
     `);
 });
 
+test('multiline (https://github.com/magicmark/composerize/issues/120)', () => {
+    expect(
+        Composerize(
+            `docker run -d --name kong \
+     --network=kong-net \
+     -e "KONG_DATABASE=postgres" \
+     -e "KONG_PG_HOST=kong-database" \
+     -e "KONG_CASSANDRA_CONTACT_POINTS=kong-database" \
+     -e "KONG_PROXY_ACCESS_LOG=/dev/stdout" \
+     -e "KONG_ADMIN_ACCESS_LOG=/dev/stdout" \
+     -e "KONG_PROXY_ERROR_LOG=/dev/stderr" \
+     -e "KONG_ADMIN_ERROR_LOG=/dev/stderr" \
+     -e "KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl" \
+     -p 8000:8000 \
+     -p 8443:8443 \
+     -p 8001:8001 \
+     -p 8444:8444 \
+     kong:latest`,
+        ),
+    ).toMatchInlineSnapshot(`
+        "version: '3.3'
+        services:
+            kong:
+                container_name: kong
+                network_mode: kong-net
+                environment:
+                    - KONG_DATABASE=postgres
+                    - KONG_PG_HOST=kong-database
+                    - KONG_CASSANDRA_CONTACT_POINTS=kong-database
+                    - KONG_PROXY_ACCESS_LOG=/dev/stdout
+                    - KONG_ADMIN_ACCESS_LOG=/dev/stdout
+                    - KONG_PROXY_ERROR_LOG=/dev/stderr
+                    - KONG_ADMIN_ERROR_LOG=/dev/stderr
+                    - 'KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl'
+                ports:
+                    - '8000:8000'
+                    - '8443:8443'
+                    - '8001:8001'
+                    - '8444:8444'
+                image: 'kong:latest'"
+    `);
+});
+

--- a/packages/composerize/__tests__/mappings.test.js
+++ b/packages/composerize/__tests__/mappings.test.js
@@ -200,6 +200,29 @@ test('command name (https://github.com/magicmark/composerize/issues/549)', () =>
     `);
     });
 
+test('gpus (https://github.com/magicmark/composerize/issues/550)', () => {
+    expect(Composerize('docker run -it --rm --gpus all -p 3000:3000 -v /opt/ai-art:/data overshard/ai-art'))
+        .toMatchInlineSnapshot(`
+        "version: '3.3'
+        services:
+            ai-art:
+                deploy:
+                    resources:
+                        reservations:
+                            devices:
+                                -
+                                    driver: nvidia
+                                    count: 1
+                                    capabilities:
+                                        - gpu
+                ports:
+                    - '3000:3000'
+                volumes:
+                    - '/opt/ai-art:/data'
+                image: overshard/ai-art"
+    `);
+    });
+
 test('command name (https://github.com/magicmark/composerize/issues/538)', () => {
     expect(
         Composerize(

--- a/packages/composerize/__tests__/mappings.test.js
+++ b/packages/composerize/__tests__/mappings.test.js
@@ -269,6 +269,29 @@ test('basic image (https://github.com/magicmark/composerize/issues/542)', () => 
     `);
 });
 
+test('volumes declaration (https://github.com/magicmark/composerize/issues/524)', () => {
+    expect(
+        Composerize(
+            'docker run --restart=unless-stopped -d --name=readymedia1 --net=host -v /my/video/path:/media -v readymediacache:/cache -e VIDEO_DIR1=/media/my_video_files ypopovych/readymedia',
+        ),
+    ).toMatchInlineSnapshot(`
+        "version: '3.3'
+        services:
+            readymedia:
+                restart: unless-stopped
+                container_name: readymedia1
+                network_mode: host
+                volumes:
+                    - '/my/video/path:/media'
+                    - 'readymediacache:/cache'
+                environment:
+                    - VIDEO_DIR1=/media/my_video_files
+                image: ypopovych/readymedia
+        volumes:
+            readymediacache: {}"
+    `);
+});
+
 test('tmpfs (https://github.com/magicmark/composerize/issues/536)', () => {
     expect(
         Composerize(

--- a/packages/composerize/src/index.js
+++ b/packages/composerize/src/index.js
@@ -42,7 +42,7 @@ export default (input: string): ?string => {
         const result = maybeGetComposeEntry(key, value);
         if (result) {
             const entries = Array.isArray(result) ? result : [result];
-            entries.forEach((entry) => {
+            entries.forEach(entry => {
                 // Store whatever the next entry will be
                 const json = getComposeJson(entry);
                 service = deepmerge(service, json);
@@ -54,18 +54,12 @@ export default (input: string): ?string => {
     service.image = image;
     if (command.length > 1) {
         let argStart = 1;
-        if (!command[1].startsWith('-')) {
-            const cmd = command[1];
-            service.command = cmd;
-            argStart = 2;
+        const commandArgsArray = [];
+        while (argStart < command.length) {
+            commandArgsArray.push(command[argStart]);
+            argStart += 1;
         }
-        if (argStart < command.length) {
-            service.args = [];
-            while (argStart < command.length) {
-                service.args.push(command[argStart]);
-                argStart += 1;
-            }
-        }
+        service.command = commandArgsArray.join(' ');
     }
 
     const serviceName = getServiceName(image);

--- a/packages/composerize/src/index.js
+++ b/packages/composerize/src/index.js
@@ -62,6 +62,23 @@ export default (input: string): ?string => {
         service.command = commandArgsArray.join(' ');
     }
 
+    const namedVolumes = [];
+    if (service.volumes) {
+        for (let volumeIndex = 0; volumeIndex < service.volumes.length; volumeIndex += 1) {
+            let source;
+            if (typeof service.volumes[volumeIndex] === 'string') {
+                const volumeName = service.volumes[volumeIndex].split(':')[0];
+                source = volumeName;
+            } else {
+                const volumeSource = service.volumes[volumeIndex].source;
+                source = volumeSource;
+            }
+            if (source && !source.includes('/') && !source.includes('$')) {
+                namedVolumes.push([source, {}]);
+            }
+        }
+    }
+
     const serviceName = getServiceName(image);
 
     // Outer template
@@ -71,6 +88,9 @@ export default (input: string): ?string => {
             [serviceName]: service,
         },
     };
+    if (namedVolumes.length > 0) {
+        result.volumes = Object.fromEntries(namedVolumes);
+    }
 
     return yamljs.stringify(result, 9, 4).trim();
 };

--- a/packages/composerize/src/logic.js
+++ b/packages/composerize/src/logic.js
@@ -42,6 +42,25 @@ export const getComposeEntry = (mapping: Mapping, value: RawValue): ComposeEntry
         }: SwitchComposeEntry);
     }
 
+    if (mapping.type === 'Gpus') {
+        return ({
+            path: 'deploy',
+            value: {
+                resources: {
+                    reservations: {
+                        devices: [
+                            {
+                                driver: 'nvidia',
+                                count: value === 'all' ? 1 : parseInt(value, 10),
+                                capabilities: ['gpu'],
+                            },
+                        ],
+                    },
+                },
+            },
+        }: KVComposeEntry);
+    }
+
     if (mapping.type === 'Ulimits') {
         const values = Array.isArray(value) ? value : [value];
 

--- a/packages/composerize/src/logic.js
+++ b/packages/composerize/src/logic.js
@@ -61,10 +61,22 @@ export const getComposeEntry = (mapping: Mapping, value: RawValue): ComposeEntry
         }: KVComposeEntry);
     }
 
+    if (mapping.type === 'Mounts') {
+        const values = Array.isArray(value) ? value : [value];
+
+        return values.map((_value) => {
+            const args = String(_value).split(',');
+            return ({
+                path: mapping.path,
+                value: [Object.fromEntries(args.map((_arg) => _arg.split('=')))],
+            }: KVComposeEntry);
+        });
+    }
+
     if (mapping.type === 'Ulimits') {
         const values = Array.isArray(value) ? value : [value];
 
-        return values.map(_value => {
+        return values.map((_value) => {
             const [limitName, limitValue] = String(_value).split('=');
             invariant(
                 limitName && limitValue,

--- a/packages/composerize/src/mappings.js
+++ b/packages/composerize/src/mappings.js
@@ -22,6 +22,7 @@ export type ArgType =
 
     // Used to store an arbitrary text value for an option
     | 'Value'
+    | 'Mounts'
     | 'Gpus';
 
 // Type to represent the structure of the docker compose mapping
@@ -81,6 +82,7 @@ export const MAPPINGS: { [string]: Mapping } = {
     name: getMapping('Value', 'container_name'),
     network: getMapping('Value', 'network_mode'),
     net: getMapping('Value', 'network_mode'), // alias for network
+    mount: getMapping('Mounts', 'volumes'),
     pid: getMapping('Value', 'pid'),
     privileged: getMapping('Switch', 'privileged'),
     publish: getMapping('Array', 'ports'),

--- a/packages/composerize/src/mappings.js
+++ b/packages/composerize/src/mappings.js
@@ -21,7 +21,8 @@ export type ArgType =
     | 'Switch'
 
     // Used to store an arbitrary text value for an option
-    | 'Value';
+    | 'Value'
+    | 'Gpus';
 
 // Type to represent the structure of the docker compose mapping
 export type Mapping = {
@@ -38,7 +39,7 @@ export type ArrayComposeEntry = {
 export type KVComposeEntry = {
     path: string,
     value: {
-        [string]: string | number,
+        [string]: string | number | any,
     },
 };
 
@@ -89,6 +90,7 @@ export const MAPPINGS: { [string]: Mapping } = {
     ulimit: getMapping('Ulimits', 'ulimits'),
     user: getMapping('Value', 'user'),
     volume: getMapping('Array', 'volumes'),
+    gpus: getMapping('Gpus', 'deploy'),
 };
 
 // Add flag mappings


### PR DESCRIPTION
Fix #524, assuming that docker-compose config is not hurt (and output itself) by the following output :
```
version: '3.3'
services:
    readymedia:
        restart: unless-stopped
        container_name: readymedia1
        network_mode: host
        volumes:
            - '/my/video/path:/media'
            - 'readymediacache:/cache'
        environment:
            - VIDEO_DIR1=/media/my_video_files
        image: ypopovych/readymedia
volumes:
    readymediacache: {}
```